### PR TITLE
Add help to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
-qa: lint test
+qa: lint test ## Lint and test the code in multiple images
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(abspath $(patsubst %/,%,$(dir $(mkfile_path))))
 
 .PHONY: *
 
-lint: php-fpm-healthcheck
+lint: php-fpm-healthcheck ## Lint code
 	docker run --rm -v ${current_dir}:/mnt:ro koalaman/shellcheck \
 	./php-fpm-healthcheck ./test/*.sh
 
-test:
+test: ## Test code in multiple images
 	$(MAKE) test-image IMAGE="php:fpm-alpine" DOCKERFILE="alpine"
 	$(MAKE) test-image IMAGE="php:7.1-fpm-alpine3.7" DOCKERFILE="alpine"
 	$(MAKE) test-image IMAGE="php:7.1-fpm-alpine3.8" DOCKERFILE="alpine"
@@ -22,3 +22,7 @@ test:
 
 test-image:
 	./test/docker.sh ${DOCKERFILE} ${IMAGE}
+
+help:
+	@echo "\033[33mUsage:\033[0m\n  make [target] [FLAGS=\"val\"...]\n\n\033[33mTargets:\033[0m"
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[32m%-18s\033[0m %s\n", $$1, $$2}' #look at this magic


### PR DESCRIPTION
## Context

Related issue #9

Adds help information to the Makefile to guide users.

## Changes

- [x] add `make help`
- [x] Document each target in Makefile
