### PR TITLE
Fix test for script being executable

### DIFF
--- a/test/testinfra/test_command.py
+++ b/test/testinfra/test_command.py
@@ -10,4 +10,4 @@ def test_healthcheck_script_is_executable(host):
     scriptFile = host.check_output("which php-fpm-healthcheck")
       
     assert host.file(scriptFile).exists is True
-    assert host.file(scriptFile).mode == 0o775
+    assert host.file(scriptFile).mode & 0o111 == 0o111


### PR DESCRIPTION
This was failing for me because the script was mode `755` rather than the expected `775`. Instead of testing a specific mode, just test that the executable bits are set for everyone.

## Changes

- [x] Tests included
- [ ] Documentation updated
- [x] Commit message is clear
