### PR TITLE
Ignore the environment when executing `cgi-fcgi`

### DIFF
--- a/php-fpm-healthcheck
+++ b/php-fpm-healthcheck
@@ -61,7 +61,7 @@ get_fpm_status() {
     if test "$VERBOSE" = 1; then printf "Trying to connect to php-fpm via: %s\\n" "$1"; fi;
     
     # Since I cannot use pipefail I'll just split these in two commands
-    FPM_STATUS=$(cgi-fcgi -bind -connect "$1" 2> /dev/null)
+    FPM_STATUS=$(env -i REQUEST_METHOD="$REQUEST_METHOD" SCRIPT_NAME="$SCRIPT_NAME" SCRIPT_FILENAME="$SCRIPT_FILENAME" cgi-fcgi -bind -connect "$1" 2> /dev/null)
     FPM_STATUS=$(echo "$FPM_STATUS" | tail +5)
 
     if test "$VERBOSE" = 1; then printf "php-fpm status output:\\n%s\\n" "$FPM_STATUS"; fi;

--- a/test/testinfra/test_fpm.py
+++ b/test/testinfra/test_fpm.py
@@ -32,6 +32,15 @@ def test_fpm_on_socket(host):
     host.run("sed -i /usr/local/etc/php-fpm.d/zz-docker.conf -e '/^listen/ s/.*/listen = 9000/'")
     host.run("kill -USR2 1")
 
+# https://github.com/renatomefi/php-fpm-healthcheck/issues/18
+@pytest.mark.php_fpm
+def test_fpm_on_socket_with_huge_env(host):
+    cmd = host.run("HUGE_ENV=\"$(dd if=/dev/zero bs=8192 count=1 | tr '\\000' '\\040')\" php-fpm-healthcheck -v")
+    assert cmd.rc == 0
+    assert "Trying to connect to php-fpm via:" in cmd.stdout
+    assert "status output:" in cmd.stdout
+    assert "pool:" in cmd.stdout
+
 @pytest.mark.alpine
 def test_exit_when_fpm_is_not_reachable_apk(host):
     cmd = host.run("FCGI_CONNECT=localhost:9001 php-fpm-healthcheck -v")

--- a/test/testinfra/test_metrics.py
+++ b/test/testinfra/test_metrics.py
@@ -2,6 +2,7 @@ import pytest
 
 @pytest.mark.php_fpm
 def test_metric_fail_accepted_conn(host):
+    host.run("kill -USR2 1") # reset accepted conn value
     cmd = host.run("php-fpm-healthcheck --accepted-conn=0")
     assert cmd.rc == 1
     assert "'accepted conn' value '1' is greater than expected '0'" in cmd.stderr


### PR DESCRIPTION
`cgi-fcgi` sends all environment variables as FastCGI parameters, which can result in enormous requests since the environment is outside of our control. Ignore all environment variables except the ones we need to use for `cgi-fcgi`.

## Context

Related issue #18

## Changes

- [X] Tests included
- [ ] Documentation updated
- [X] Commit message is clear
