### PR TITLE
Create setup and tear down fixture for fpm changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,11 @@ test: ## Test code in multiple images
 	$(MAKE) test-image IMAGE="php:7.1-fpm-alpine3.8" DOCKERFILE="alpine"
 	$(MAKE) test-image IMAGE="php:7.2-fpm-alpine3.7" DOCKERFILE="alpine"
 	$(MAKE) test-image IMAGE="php:7.2-fpm-alpine3.8" DOCKERFILE="alpine"
-	$(MAKE) test-image IMAGE="php:7.3-rc-fpm-alpine3.8" DOCKERFILE="alpine"
+	$(MAKE) test-image IMAGE="php:7.3-fpm-alpine3.8" DOCKERFILE="alpine"
+	$(MAKE) test-image IMAGE="php:7.3-fpm-alpine3.9" DOCKERFILE="alpine"
 	$(MAKE) test-image IMAGE="php:7.1-fpm-stretch" DOCKERFILE="stretch"
 	$(MAKE) test-image IMAGE="php:7.2-fpm-stretch" DOCKERFILE="stretch"
-	$(MAKE) test-image IMAGE="php:7.3-rc-fpm-stretch" DOCKERFILE="stretch"
+	$(MAKE) test-image IMAGE="php:7.3-fpm-stretch" DOCKERFILE="stretch"
 
 test-image:
 	./test/docker.sh ${DOCKERFILE} ${IMAGE}

--- a/test/testinfra/test_fpm.py
+++ b/test/testinfra/test_fpm.py
@@ -1,7 +1,21 @@
 import pytest
 
+@pytest.fixture(scope="module")
+def setup_fpm_fixture(host, request):
+    print('Backing up current fpm configuration')
+    host.run("cp /usr/local/etc/php-fpm.d/zz-docker.conf /tmp/zz-docker.conf")
+    yield 1
+    print('Recovering fpm configuration and reloading after module')
+    host.run("cp /tmp/zz-docker.conf /usr/local/etc/php-fpm.d/zz-docker.conf")
+
+@pytest.fixture
+def setup_fpm_to_default_fixture(host, request, setup_fpm_fixture):
+    print('Recovering fpm configuration and reloading')
+    host.run("cp -f /tmp/zz-docker.conf /usr/local/etc/php-fpm.d/zz-docker.conf")
+    host.run("kill -USR2 1")
+
 @pytest.mark.php_fpm
-def test_exit_when_no_status_page_is_configured(host):
+def test_exit_when_no_status_page_is_configured(host, setup_fpm_to_default_fixture):
     # disable fpm status page
     host.run("sed -i /usr/local/etc/php-fpm.d/zz-docker.conf -e '/pm.status_path/ s/^;*/;/'")
     host.run("kill -USR2 1")
@@ -12,12 +26,8 @@ def test_exit_when_no_status_page_is_configured(host):
     assert "status output:" in cmd.stdout
     assert "php-fpm status page non reachable" in cmd.stderr
 
-    # enable fpm status page back
-    host.run("sed -i /usr/local/etc/php-fpm.d/zz-docker.conf -e '/;pm.status_path/ s/^;*//'")
-    host.run("kill -USR2 1")
-
 @pytest.mark.php_fpm
-def test_fpm_on_socket(host):
+def test_fpm_on_socket(host, setup_fpm_to_default_fixture):
     # change fpm to socket
     host.run("sed -i /usr/local/etc/php-fpm.d/zz-docker.conf -e '/^listen/ s/.*/listen = \\/var\\/run\\/php-fpm.sock/'")
     host.run("kill -USR2 1")
@@ -28,13 +38,9 @@ def test_fpm_on_socket(host):
     assert "status output:" in cmd.stdout
     assert "pool:" in cmd.stdout
 
-    # change fpm back to port 9000
-    host.run("sed -i /usr/local/etc/php-fpm.d/zz-docker.conf -e '/^listen/ s/.*/listen = 9000/'")
-    host.run("kill -USR2 1")
-
 # https://github.com/renatomefi/php-fpm-healthcheck/issues/18
 @pytest.mark.php_fpm
-def test_fpm_on_socket_with_huge_env(host):
+def test_fpm_on_socket_with_huge_env(host, setup_fpm_to_default_fixture):
     cmd = host.run("HUGE_ENV=\"$(dd if=/dev/zero bs=8192 count=1 | tr '\\000' '\\040')\" php-fpm-healthcheck -v")
     assert cmd.rc == 0
     assert "Trying to connect to php-fpm via:" in cmd.stdout
@@ -42,25 +48,25 @@ def test_fpm_on_socket_with_huge_env(host):
     assert "pool:" in cmd.stdout
 
 @pytest.mark.alpine
-def test_exit_when_fpm_is_not_reachable_apk(host):
+def test_exit_when_fpm_is_not_reachable_apk(host, setup_fpm_to_default_fixture):
     cmd = host.run("FCGI_CONNECT=localhost:9001 php-fpm-healthcheck -v")
     assert cmd.rc == 9
     assert "Trying to connect to php-fpm via: localhost:9001" in cmd.stdout
 
 @pytest.mark.alpine
-def test_exit_when_fpm_is_invalid_host_apk(host):
+def test_exit_when_fpm_is_invalid_host_apk(host, setup_fpm_to_default_fixture):
     cmd = host.run("FCGI_CONNECT=abc php-fpm-healthcheck -v")
     assert cmd.rc == 9
     assert "Trying to connect to php-fpm via: abc" in cmd.stdout
 
 @pytest.mark.stretch
-def test_exit_when_fpm_is_not_reachable_apt(host):
+def test_exit_when_fpm_is_not_reachable_apt(host, setup_fpm_to_default_fixture):
     cmd = host.run("FCGI_CONNECT=localhost:9001 php-fpm-healthcheck -v")
     assert cmd.rc == 111
     assert "Trying to connect to php-fpm via: localhost:9001" in cmd.stdout
 
 @pytest.mark.stretch
-def test_exit_when_fpm_is_invalid_host_apt(host):
+def test_exit_when_fpm_is_invalid_host_apt(host, setup_fpm_to_default_fixture):
     cmd = host.run("FCGI_CONNECT=abc php-fpm-healthcheck -v")
     assert cmd.rc == 2
     assert "Trying to connect to php-fpm via: abc" in cmd.stdout


### PR DESCRIPTION
## Context

Some fpm tests mutate its configuration, fixtures as now added to make this process easier and guarantee state between tests

## Changes

- [x] Tests included
- [ ] Documentation updated
- [x] Commit message is clear
