### PR TITLE
Fix queue-len related options

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ echo $?
 And you can also check if you have more than `10` processes in the queue:
 
 ```console
-$ php-fpm-healthcheck --accepted-conn=3000 --listen-queue-len=10
+$ php-fpm-healthcheck --accepted-conn=3000 --listen-queue=10
 $ echo $?
 0
 ```
@@ -155,7 +155,7 @@ More and more people are looking for health checks on kubernetes for php-fpm, he
             exec:
                 command:
                     - php-fpm-healthcheck
-                    - --listen-queue-len=10 # fails if there are more than 10 processes waiting in the fpm queue
+                    - --listen-queue=10 # fails if there are more than 10 processes waiting in the fpm queue
                     - --accepted-conn=5000 # fails after fpm has served more than 5k requests, this will force the pod to reset, use with caution
             initialDelaySeconds: 0
             periodSeconds: 10

--- a/php-fpm-healthcheck
+++ b/php-fpm-healthcheck
@@ -77,7 +77,7 @@ get_fpm_status() {
 check_fpm_health_by() {
     OPTION=$(echo "$1" | sed 's/--//g; s/-/ /g;')
     VALUE_EXPECTED="$2";
-    VALUE_ACTUAL=$(echo "$FPM_STATUS" | grep "^$OPTION" | cut -d: -f2 | sed 's/ //g')
+    VALUE_ACTUAL=$(echo "$FPM_STATUS" | grep "^$OPTION:" | cut -d: -f2 | sed 's/ //g')
 
     if test "$VERBOSE" = 1; then printf "'%s' value '%s' and expected is less than '%s'\\n" "$OPTION" "$VALUE_ACTUAL" "$VALUE_EXPECTED"; fi;
 

--- a/test/testinfra/test_metrics.py
+++ b/test/testinfra/test_metrics.py
@@ -22,3 +22,11 @@ def test_metric_accepted_conn(host):
     assert "Trying to connect to php-fpm via:" in cmd.stdout
     assert "status output:" in cmd.stdout
     assert "pool:" in cmd.stdout
+
+@pytest.mark.php_fpm
+def test_listen_queue_len_and_listen_queue_vars_are_parsed_correctly(host):
+    cmd = host.run("php-fpm-healthcheck --verbose --listen-queue=5 --listen-queue-len=256")
+    assert cmd.rc == 0
+    assert "Trying to connect to php-fpm via:" in cmd.stdout
+    assert "'listen queue' value '0' and expected is less than '5" in cmd.stdout
+    assert "'listen queue len' value '128' and expected is less than '256'" in cmd.stdout


### PR DESCRIPTION
Signed-off-by: Tim Jespers <t.jesp3rs@gmail.com>

## Context

Related issue #23

This PR fixes a bug when trying to use a healthcheck based on the amount of requests currently in the PHP-FPM queue.

e.g. when trying to use `php-fpm-healthcheck -v --listen-queue` errors because `listen-queue` and `listen-queue-len` both match the `grep "^$OPTION"` condition, by making the pattern explicit (looking for `listen queue:` instrad of `listen queue`) will prevent this from happening.

As a small clarification about the PHP-FPM status regarding queue output:

- `max listen queue`: the highest amount of requests that the queue has reached since PHP-FPM was booted
- `listen queue`: the current amount of requests in the listen queue
- `listen queue len`: the max amount of requests PHP-FPM can store in it's queue (defaults to 128 for most operating systems as that is the max a socket can handle in most cases)

see also: https://brandonwamboldt.ca/understanding-the-php-fpm-status-page-1603/

## Changes

- [x] Tests included
- [x] Documentation updated
- [x] Commit message is clear
