### PR TITLE
Build new versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ default_workflow_jobs: &default_workflow_jobs
         - lint
   - test-7.3:
       requires:
+        - lint  
+  - test-7.4:
+      requires:
         - lint
         
 workflows:
@@ -31,7 +34,6 @@ jobs:
     steps:
       - checkout
       - run: make test-image IMAGE="php:fpm-alpine" DOCKERFILE="alpine"
-      - run: make test-image IMAGE="php:fpm-stretch" DOCKERFILE="stretch"
 
   test-7.1:
     machine: true
@@ -53,5 +55,15 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: make test-image IMAGE="php:7.3-rc-fpm-alpine3.8" DOCKERFILE="alpine"
-      - run: make test-image IMAGE="php:7.3-rc-fpm-stretch" DOCKERFILE="stretch"
+      - run: make test-image IMAGE="php:7.3-fpm-alpine3.8" DOCKERFILE="alpine"
+      - run: make test-image IMAGE="php:7.3-fpm-alpine3.9" DOCKERFILE="alpine"
+      - run: make test-image IMAGE="php:7.3-fpm-alpine3.10" DOCKERFILE="alpine"
+      - run: make test-image IMAGE="php:7.3-fpm-alpine3.11" DOCKERFILE="alpine"
+      - run: make test-image IMAGE="php:7.3-fpm-stretch" DOCKERFILE="stretch"
+
+  test-7.4:
+    machine: true
+    steps:
+      - checkout
+      - run: make test-image IMAGE="php:7.4-fpm-alpine3.10" DOCKERFILE="alpine"
+      - run: make test-image IMAGE="php:7.4-fpm-alpine3.11" DOCKERFILE="alpine"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
     steps:
       - checkout
       - run: make test-image IMAGE="php:fpm-alpine" DOCKERFILE="alpine"
+      - run: make test-image IMAGE="php:fpm-buster" DOCKERFILE="stretch"
 
   test-7.1:
     machine: true
@@ -67,3 +68,4 @@ jobs:
       - checkout
       - run: make test-image IMAGE="php:7.4-fpm-alpine3.10" DOCKERFILE="alpine"
       - run: make test-image IMAGE="php:7.4-fpm-alpine3.11" DOCKERFILE="alpine"
+      - run: make test-image IMAGE="php:7.4-fpm-buster" DOCKERFILE="stretch"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ lint: php-fpm-healthcheck ## Lint code
 
 test: ## Test code in multiple images
 	$(MAKE) test-image IMAGE="php:fpm-alpine" DOCKERFILE="alpine"
+	$(MAKE) test-image IMAGE="php:fpm-buster" DOCKERFILE="buster"
 	$(MAKE) test-image IMAGE="php:7.1-fpm-alpine3.7" DOCKERFILE="alpine"
 	$(MAKE) test-image IMAGE="php:7.1-fpm-alpine3.8" DOCKERFILE="alpine"
 	$(MAKE) test-image IMAGE="php:7.2-fpm-alpine3.7" DOCKERFILE="alpine"
@@ -22,6 +23,7 @@ test: ## Test code in multiple images
 	$(MAKE) test-image IMAGE="php:7.1-fpm-stretch" DOCKERFILE="stretch"
 	$(MAKE) test-image IMAGE="php:7.2-fpm-stretch" DOCKERFILE="stretch"
 	$(MAKE) test-image IMAGE="php:7.3-fpm-stretch" DOCKERFILE="stretch"
+	$(MAKE) test-image IMAGE="php:7.4-fpm-buster" DOCKERFILE="buster"
 
 test-image:
 	./test/docker.sh ${DOCKERFILE} ${IMAGE}

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ test: ## Test code in multiple images
 	$(MAKE) test-image IMAGE="php:7.2-fpm-alpine3.8" DOCKERFILE="alpine"
 	$(MAKE) test-image IMAGE="php:7.3-fpm-alpine3.8" DOCKERFILE="alpine"
 	$(MAKE) test-image IMAGE="php:7.3-fpm-alpine3.9" DOCKERFILE="alpine"
+	$(MAKE) test-image IMAGE="php:7.4-fpm-alpine3.10" DOCKERFILE="alpine"
+	$(MAKE) test-image IMAGE="php:7.4-fpm-alpine3.11" DOCKERFILE="alpine"
 	$(MAKE) test-image IMAGE="php:7.1-fpm-stretch" DOCKERFILE="stretch"
 	$(MAKE) test-image IMAGE="php:7.2-fpm-stretch" DOCKERFILE="stretch"
 	$(MAKE) test-image IMAGE="php:7.3-fpm-stretch" DOCKERFILE="stretch"

--- a/test/Dockerfile-buster
+++ b/test/Dockerfile-buster
@@ -1,0 +1,11 @@
+FROM php:7.4-fpm-buster
+
+# Required software
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y libfcgi-bin
+
+# Enable php fpm status page
+RUN set -xe && echo "pm.status_path = /status" >> /usr/local/etc/php-fpm.d/zz-docker.conf
+
+COPY ./php-fpm-healthcheck /usr/local/bin/

--- a/test/docker.sh
+++ b/test/docker.sh
@@ -11,7 +11,7 @@ set -eEuo pipefail
 function cleanup {
 docker stop "$CONTAINER" 1> /dev/null
     echo "container $CONTAINER: stopped"
-    docker rmi -f "$DOCKER_TAG_TEMPORARY"
+     docker rmi -f "$DOCKER_TAG_TEMPORARY"
 }
 trap cleanup EXIT
 

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,2 +1,7 @@
 [pytest]
 python_files = testinfra/test_*.py
+# OS markers are necessary as there are minor differences between fpm and cgi binaries
+markers =
+    php_fpm: All php-fpm tests
+    alpine: Tests compatible with Alpine images
+    stretch: Tests compatible with Debian Stretch images

--- a/test/testinfra/test_fpm.py
+++ b/test/testinfra/test_fpm.py
@@ -50,13 +50,13 @@ def test_fpm_on_socket_with_huge_env(host, setup_fpm_to_default_fixture):
 @pytest.mark.alpine
 def test_exit_when_fpm_is_not_reachable_apk(host, setup_fpm_to_default_fixture):
     cmd = host.run("FCGI_CONNECT=localhost:9001 php-fpm-healthcheck -v")
-    assert cmd.rc == 9
+    assert cmd.rc in (111, 9)
     assert "Trying to connect to php-fpm via: localhost:9001" in cmd.stdout
 
 @pytest.mark.alpine
 def test_exit_when_fpm_is_invalid_host_apk(host, setup_fpm_to_default_fixture):
     cmd = host.run("FCGI_CONNECT=abc php-fpm-healthcheck -v")
-    assert cmd.rc == 9
+    assert cmd.rc in (2, 9)
     assert "Trying to connect to php-fpm via: abc" in cmd.stdout
 
 @pytest.mark.stretch

--- a/test/testinfra/test_metrics.py
+++ b/test/testinfra/test_metrics.py
@@ -25,8 +25,8 @@ def test_metric_accepted_conn(host):
 
 @pytest.mark.php_fpm
 def test_listen_queue_len_and_listen_queue_vars_are_parsed_correctly(host):
-    cmd = host.run("php-fpm-healthcheck --verbose --listen-queue=5 --listen-queue-len=256")
+    cmd = host.run("php-fpm-healthcheck --verbose --listen-queue=5 --max-listen-queue=1024")
     assert cmd.rc == 0
     assert "Trying to connect to php-fpm via:" in cmd.stdout
     assert "'listen queue' value '0' and expected is less than '5" in cmd.stdout
-    assert "'listen queue len' value '128' and expected is less than '256'" in cmd.stdout
+    assert "'max listen queue' value '0' and expected is less than '1024'" in cmd.stdout


### PR DESCRIPTION
## Context

Test Alpine 3.10 and 3.11 for PHP 7.4
Test Debian buster for PHP 7.4

Certain values have changed, there's a new `listen queue len` default value, instead of testing it I'm now checking the `max listen queue`.
The newer versions seems to have similar exit status codes, the tests now accepts either of them.

Fixed #29 

## Changes

- [x] Tests included
- [ ] Documentation updated
- [x] Commit message is clear
