### PR TITLE
Allow definition of custom controller to render healthy info

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,23 @@ $ echo $?
 0
 ```
 
+### Custom status page rendered by a controller
+
+_Since v0.6.0_
+
+While using php-fpm status page as your health check data source, only the use of the default `/status` path or defining your
+preference using `FCGI_STATUS_PATH` already does the job. In case of use of a custom controller to render those definitions,
+it also becomes necessary to define `FCGI_CONTROLLER_SCRIPT` env var with the script, as an `index.php`, that starts your router 
+and controller:
+
+```console
+$ FCGI_STATUS_PATH=/custom-status-path FCGI_CONTROLLER_SCRIPT=/var/www/project/index.php php-fpm-healthcheck -v
+Trying to connect to php-fpm via: localhost:9000/custom-status-path
+...
+$ echo $?
+0
+```
+
 ## Kubernetes example
 
 More and more people are looking for health checks on kubernetes for php-fpm, here is an example of livenessProbe and readinessProbe:

--- a/php-fpm-healthcheck
+++ b/php-fpm-healthcheck
@@ -52,10 +52,10 @@ command -v grep 1> /dev/null || { >&2 echo "Make sure grep is installed (i.e. ap
 # Get status from fastcgi connection
 # $1 - cgi-fcgi connect argument
 get_fpm_status() {
-    if test "$VERBOSE" = 1; then printf "Trying to connect to php-fpm via: %s%s\\n" "$1" "$SCRIPT_NAME"; fi;
-    
+    if test "$VERBOSE" = 1; then printf "Trying to connect to php-fpm via: %s%s\\n" "$1" "$REQUEST_URI"; fi;
+
     # Since I cannot use pipefail I'll just split these in two commands
-    FPM_STATUS=$(env -i REQUEST_METHOD="$REQUEST_METHOD" SCRIPT_NAME="$SCRIPT_NAME" SCRIPT_FILENAME="$SCRIPT_FILENAME" "$FCGI_CMD_PATH" -bind -connect "$1" 2> /dev/null)
+    FPM_STATUS=$(env -i REQUEST_METHOD="$REQUEST_METHOD" REQUEST_URI="$REQUEST_URI" SCRIPT_NAME="$SCRIPT_NAME" SCRIPT_FILENAME="$SCRIPT_FILENAME" "$FCGI_CMD_PATH" -bind -connect "$1" 2> /dev/null)
     FPM_STATUS=$(echo "$FPM_STATUS" | tail +5)
 
     if test "$VERBOSE" = 1; then printf "php-fpm status output:\\n%s\\n" "$FPM_STATUS"; fi;
@@ -119,8 +119,10 @@ FCGI_CONNECT_DEFAULT="localhost:9000"
 FCGI_STATUS_PATH_DEFAULT="/status"
 
 export REQUEST_METHOD="GET"
-export SCRIPT_NAME="${FCGI_STATUS_PATH:-$FCGI_STATUS_PATH_DEFAULT}"
-export SCRIPT_FILENAME="${FCGI_STATUS_PATH:-$FCGI_STATUS_PATH_DEFAULT}"
+export REQUEST_URI="${FCGI_STATUS_PATH:-$FCGI_STATUS_PATH_DEFAULT}"
+export SCRIPT_NAME="${FCGI_CONTROLLER_SCRIPT:-$REQUEST_URI}"
+export SCRIPT_FILENAME="${FCGI_CONTROLLER_SCRIPT:-$REQUEST_URI}"
+
 FCGI_CONNECT="${FCGI_CONNECT:-$FCGI_CONNECT_DEFAULT}"
 
 VERBOSE=0


### PR DESCRIPTION
## Context

The goal of this pull request is allow application controllers that are rendering / checking application healthy to also be used on the script as starting point of health check. The main issue found on the original script was that frameworks as Symfony and Laravel rely on a single entry file to start their routings, and the original php-fpm-healthcheck wasn't allowing the combination of the SCRIPT_NAME and REQUEST_URI on its definition.

## Changes

- [x] Tests included
- [x] Documentation updated
- [x] Commit message is clear
