### PR TITLE
Fix outdated parameter name in comment example

### DIFF
--- a/php-fpm-healthcheck
+++ b/php-fpm-healthcheck
@@ -11,7 +11,7 @@
 # The script will fail in case the 'active processes' is bigger than 6.
 #
 # You can combine multiple options as well, the first one to fail will fail the healthcheck
-# i.e.: ./php-fpm-healthcheck --listen-queue-len=10 --active-processes=6
+# i.e.: ./php-fpm-healthcheck --listen-queue=10 --active-processes=6
 #
 # Ping mode (exit 0 if php-fpm returned data): ./php-fpm-healthcheck
 #


### PR DESCRIPTION
## Context

Related issue N/A

Fixes CLI option name from outdated one to an actual name

## Changes

- [ ] Tests included
- [x] Documentation updated
- [x] Commit message is clear
