### PR TITLE
fix(ci): use correct Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - checkout
       - run: make test-image IMAGE="php:fpm-alpine" DOCKERFILE="alpine"
-      - run: make test-image IMAGE="php:fpm-buster" DOCKERFILE="stretch"
+      - run: make test-image IMAGE="php:fpm-buster" DOCKERFILE="buster"
 
   test-7.1:
     machine: true
@@ -68,4 +68,4 @@ jobs:
       - checkout
       - run: make test-image IMAGE="php:7.4-fpm-alpine3.10" DOCKERFILE="alpine"
       - run: make test-image IMAGE="php:7.4-fpm-alpine3.11" DOCKERFILE="alpine"
-      - run: make test-image IMAGE="php:7.4-fpm-buster" DOCKERFILE="stretch"
+      - run: make test-image IMAGE="php:7.4-fpm-buster" DOCKERFILE="buster"


### PR DESCRIPTION
## Context

See: https://github.com/renatomefi/php-fpm-healthcheck/commit/912f2b23e439895d75b97e34470172853af05dab#r52864310

CI doesn't seem to test buster images correctly.

## Changes

- [ ] Tests included
- [ ] Documentation updated
- [x] Commit message is clear
