### PR TITLE
Fix check for broken fpm-status page

### DIFF
--- a/php-fpm-healthcheck
+++ b/php-fpm-healthcheck
@@ -60,7 +60,7 @@ get_fpm_status() {
 
     if test "$VERBOSE" = 1; then printf "php-fpm status output:\\n%s\\n" "$FPM_STATUS"; fi;
 
-    if test "$FPM_STATUS" = "File not found."; then
+    if [ "$FPM_STATUS" = "File not found." ] || [ "${FPM_STATUS#*File not found.}" != "$FPM_STATUS" ] || [ "$FPM_STATUS" = "Primary script unknown" ]; then
         >&2 printf "php-fpm status page non reachable\\n";
         exit 8;
     fi;


### PR DESCRIPTION
## Context

This fix catches all different versions of output that can happen for a non-existing fpm status page.

For example for the php-fpm 7.4 alpine image only "Primary script unknown" is returned. Not sure if this is due to different php versions or if it's always been this way.

I've also noticed that Kubernetes readiness + liveness probes does not catch the output when sent to stderr so you might want to consider removing >&2 from error messages. We are running without them internally and that works great with Kubernetes.

## Changes

- [ ] Tests included
- [ ] Documentation updated
- [X] Commit message is clear
